### PR TITLE
fix: parse plaintext function calls and normalize content arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ One extension. Every model VS Code can see. Standard API. Built for agents.
 - **OpenAI-compatible** — `/v1/chat/completions`, `/v1/models` with streaming (SSE)
 - **Auto-discovery** — finds every language model registered in VS Code
 - **Tool forwarding** — pass OpenAI-format tools, get `tool_calls` back
+- **Multi-provider content handling** — normalises Anthropic-style content arrays, OpenAI strings, and Gemini parts into a consistent format
+- **XML tool call fallback** — when native tool forwarding isn't available, parses Claude's XML `<function_calls>` output into proper `tool_calls` objects
 - **Rate limiting** — configurable per-minute request cap
 - **API key auth** — optional Bearer token authentication
 - **Zero dependencies** — pure Node.js HTTP, no Express, no frameworks
@@ -44,6 +46,21 @@ Any model available through VS Code's Language Model API is automatically expose
 - Any other models registered via the VS Code Language Model API
 
 Run `GET /v1/models` to see what's available in your setup.
+
+## Provider Compatibility
+
+OpenWire normalises differences between providers so callers always get a consistent OpenAI-format response:
+
+| Provider | Content format | Tool calling | Status |
+|----------|---------------|-------------|--------|
+| **Claude** (Anthropic) | Array of `{"type":"text","text":"..."}` parts | Native via VS Code API; XML `<function_calls>` fallback parsed automatically | ✅ Full support |
+| **GPT** (OpenAI) | Plain string | Native `tool_calls` via VS Code API | ✅ Full support |
+| **Gemini** (Google) | Plain string or parts array | Native via VS Code API | ✅ Full support |
+| **Ollama** (local) | Plain string | Depends on model capability | ✅ Supported |
+
+**Content normalisation** — Incoming messages with `content` as an array of content parts (Anthropic format), a plain string (OpenAI/Gemini), or null are all normalised to plain strings before forwarding to the VS Code LM API.
+
+**Tool call fallback** — When the VS Code LM API can't forward tools natively (e.g. older VS Code versions), Claude may output tool calls as XML. OpenWire detects and converts these to standard `tool_calls` objects in the response, so callers never see raw XML.
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "open-wire",
 	"displayName": "OpenWire",
 	"description": "Expose VS Code language models as an OpenAI-compatible REST API for agents and tools",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"publisher": "lewiswigmore",
 	"license": "MIT",
 	"icon": "media/icon.png",

--- a/src/routes/chat.test.ts
+++ b/src/routes/chat.test.ts
@@ -1,0 +1,148 @@
+import * as assert from 'assert';
+
+/**
+ * Standalone copies of the pure functions from chat.ts for testing
+ * (the originals depend on the vscode module which isn't available outside the extension host).
+ */
+
+// -- normalizeContent ---------------------------------------------------------
+
+function normalizeContent(content: unknown): string {
+	if (typeof content === 'string') return content;
+	if (Array.isArray(content)) {
+		return content
+			.filter((p: any) => typeof p === 'string' || p?.type === 'text')
+			.map((p: any) => typeof p === 'string' ? p : (p?.text ?? ''))
+			.join('');
+	}
+	if (content == null) return '';
+	return String(content);
+}
+
+// -- parseXmlToolCalls --------------------------------------------------------
+
+function parseXmlToolCalls(text: string): { cleanedText: string; toolCalls: { name: string; arguments: string }[] } {
+	const toolCalls: { name: string; arguments: string }[] = [];
+	const cleaned = text.replace(
+		/<function_calls>\s*([\s\S]*?)<\/function_calls>/g,
+		(_match, block: string) => {
+			for (const inv of block.matchAll(/<invoke\s+name="([^"]+)">\s*([\s\S]*?)<\/invoke>/g)) {
+				const params: Record<string, string> = {};
+				for (const p of inv[2].matchAll(/<parameter\s+name="([^"]+)">([\s\S]*?)<\/parameter>/g)) {
+					params[p[1]] = p[2];
+				}
+				toolCalls.push({
+					name: inv[1],
+					arguments: JSON.stringify(params),
+				});
+			}
+			return '';
+		},
+	);
+	return { cleanedText: cleaned.trim(), toolCalls };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void) {
+	try {
+		fn();
+		passed++;
+		console.log(`  ✓ ${name}`);
+	} catch (e: any) {
+		failed++;
+		console.log(`  ✗ ${name}`);
+		console.log(`    ${e.message}`);
+	}
+}
+
+console.log('\nnormalizeContent');
+
+test('passes through plain strings', () => {
+	assert.strictEqual(normalizeContent('hello'), 'hello');
+});
+
+test('extracts text from Anthropic content array', () => {
+	const input = [{ type: 'text', text: 'Hello ' }, { type: 'text', text: 'world' }];
+	assert.strictEqual(normalizeContent(input), 'Hello world');
+});
+
+test('handles mixed string and object arrays', () => {
+	const input = ['Hello ', { type: 'text', text: 'world' }];
+	assert.strictEqual(normalizeContent(input), 'Hello world');
+});
+
+test('skips non-text content parts (e.g. images)', () => {
+	const input = [
+		{ type: 'text', text: 'desc: ' },
+		{ type: 'image_url', image_url: { url: 'data:...' } },
+	];
+	assert.strictEqual(normalizeContent(input), 'desc: ');
+});
+
+test('returns empty string for null/undefined', () => {
+	assert.strictEqual(normalizeContent(null), '');
+	assert.strictEqual(normalizeContent(undefined), '');
+});
+
+test('stringifies other types', () => {
+	assert.strictEqual(normalizeContent(42), '42');
+});
+
+console.log('\nparseXmlToolCalls');
+
+test('parses single function call', () => {
+	const input = `Let me check that.\n<function_calls>\n<invoke name="exec">\n<parameter name="command">gh auth status 2>&1</parameter>\n</invoke>\n</function_calls>`;
+	const { cleanedText, toolCalls } = parseXmlToolCalls(input);
+	assert.strictEqual(cleanedText, 'Let me check that.');
+	assert.strictEqual(toolCalls.length, 1);
+	assert.strictEqual(toolCalls[0].name, 'exec');
+	assert.deepStrictEqual(JSON.parse(toolCalls[0].arguments), { command: 'gh auth status 2>&1' });
+});
+
+test('parses multiple function calls', () => {
+	const input = `<function_calls>\n<invoke name="read">\n<parameter name="path">/tmp/a.txt</parameter>\n</invoke>\n<invoke name="exec">\n<parameter name="command">ls -la</parameter>\n</invoke>\n</function_calls>`;
+	const { toolCalls } = parseXmlToolCalls(input);
+	assert.strictEqual(toolCalls.length, 2);
+	assert.strictEqual(toolCalls[0].name, 'read');
+	assert.strictEqual(toolCalls[1].name, 'exec');
+});
+
+test('parses multiple parameters', () => {
+	const input = `<function_calls>\n<invoke name="write">\n<parameter name="path">/tmp/out.txt</parameter>\n<parameter name="content">hello world</parameter>\n</invoke>\n</function_calls>`;
+	const { toolCalls } = parseXmlToolCalls(input);
+	assert.strictEqual(toolCalls.length, 1);
+	const args = JSON.parse(toolCalls[0].arguments);
+	assert.strictEqual(args.path, '/tmp/out.txt');
+	assert.strictEqual(args.content, 'hello world');
+});
+
+test('returns original text when no function calls present', () => {
+	const input = 'Just a normal response.';
+	const { cleanedText, toolCalls } = parseXmlToolCalls(input);
+	assert.strictEqual(cleanedText, 'Just a normal response.');
+	assert.strictEqual(toolCalls.length, 0);
+});
+
+test('handles text before and after function calls', () => {
+	const input = `Before text.\n<function_calls>\n<invoke name="exec">\n<parameter name="command">echo hi</parameter>\n</invoke>\n</function_calls>\nAfter text.`;
+	const { cleanedText, toolCalls } = parseXmlToolCalls(input);
+	assert.ok(cleanedText.includes('Before text.'));
+	assert.ok(cleanedText.includes('After text.'));
+	assert.ok(!cleanedText.includes('function_calls'));
+	assert.strictEqual(toolCalls.length, 1);
+});
+
+test('handles multiple separate function_calls blocks', () => {
+	const input = `First call:\n<function_calls>\n<invoke name="exec">\n<parameter name="command">echo 1</parameter>\n</invoke>\n</function_calls>\nThen:\n<function_calls>\n<invoke name="exec">\n<parameter name="command">echo 2</parameter>\n</invoke>\n</function_calls>`;
+	const { toolCalls } = parseXmlToolCalls(input);
+	assert.strictEqual(toolCalls.length, 2);
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -11,12 +11,25 @@ export interface ChatMessage {
 	tool_call_id?: string;
 }
 
+/** Extract plain text from content that may be a string, array of content parts, or other format */
+function normalizeContent(content: unknown): string {
+	if (typeof content === 'string') return content;
+	if (Array.isArray(content)) {
+		return content
+			.filter((p: any) => typeof p === 'string' || p?.type === 'text')
+			.map((p: any) => typeof p === 'string' ? p : (p?.text ?? ''))
+			.join('');
+	}
+	if (content == null) return '';
+	return String(content);
+}
+
 /** Normalise incoming messages to a flat role+content array */
 export function normalizeMessages(raw: unknown): ChatMessage[] {
 	if (!Array.isArray(raw)) return [];
 	return raw.map(m => ({
 		role: m.role === 'developer' ? 'system' : m.role,
-		content: m.content,
+		content: normalizeContent(m.content),
 		tool_calls: m.tool_calls,
 		tool_call_id: m.tool_call_id,
 	}));
@@ -55,6 +68,32 @@ function injectSystemPrompt(msgs: ChatMessage[], prompt: string): ChatMessage[] 
 	if (!prompt) return msgs;
 	if (msgs.some(m => m.role === 'system')) return msgs;
 	return [{ role: 'system', content: prompt }, ...msgs];
+}
+
+/**
+ * Parse XML-style function calls from model text output.
+ * Claude falls back to this format when native tool calling isn't available.
+ */
+function parseXmlToolCalls(text: string): { cleanedText: string; toolCalls: any[] } {
+	const toolCalls: any[] = [];
+	const cleaned = text.replace(
+		/<function_calls>\s*([\s\S]*?)<\/function_calls>/g,
+		(_match, block: string) => {
+			for (const inv of block.matchAll(/<invoke\s+name="([^"]+)">\s*([\s\S]*?)<\/invoke>/g)) {
+				const params: Record<string, string> = {};
+				for (const p of inv[2].matchAll(/<parameter\s+name="([^"]+)">([\s\S]*?)<\/parameter>/g)) {
+					params[p[1]] = p[2];
+				}
+				toolCalls.push({
+					id: `call_${randomUUID()}`,
+					type: 'function',
+					function: { name: inv[1], arguments: JSON.stringify(params) },
+				});
+			}
+			return '';
+		},
+	);
+	return { cleanedText: cleaned.trim(), toolCalls };
 }
 
 /** Non-streaming chat completion */
@@ -113,6 +152,13 @@ export async function processChatCompletion(
 					function: { name: part.name, arguments: JSON.stringify(part.input) },
 				});
 			}
+		}
+
+		// If no native tool calls detected, check for XML-format function calls in text
+		if (toolCalls.length === 0 && content.includes('<function_calls>')) {
+			const parsed = parseXmlToolCalls(content);
+			toolCalls.push(...parsed.toolCalls);
+			content = parsed.cleanedText;
 		}
 
 		const requestId = `chatcmpl-${randomUUID()}`;
@@ -209,57 +255,145 @@ export async function processStreamingChatCompletion(
 
 	try {
 		const response = await lm.sendRequest(lmMessages, options, cts.token);
+		const toolsForwarded = !!(options.tools && options.tools.length > 0);
+		const needsToolParsing = !toolsForwarded && payload?.tools?.length > 0;
 
-		for await (const part of response.stream) {
-			if (cts.token.isCancellationRequested) break;
-
-			if (part instanceof vscode.LanguageModelTextPart) {
-				const chunk = {
-					id: requestId,
-					object: 'chat.completion.chunk',
-					created,
-					model: modelId,
-					choices: [{
-						index: 0,
-						delta: { content: part.value },
-						finish_reason: null,
-					}],
-				};
-				res.write(`data: ${JSON.stringify(chunk)}\n\n`);
-			} else if (part instanceof vscode.LanguageModelToolCallPart) {
-				const chunk = {
-					id: requestId,
-					object: 'chat.completion.chunk',
-					created,
-					model: modelId,
-					choices: [{
-						index: 0,
-						delta: {
-							tool_calls: [{
-								index: 0,
-								id: part.callId || `call_${randomUUID()}`,
-								type: 'function',
-								function: { name: part.name, arguments: JSON.stringify(part.input) },
-							}],
-						},
-						finish_reason: null,
-					}],
-				};
-				res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+		if (needsToolParsing) {
+			// Buffer mode: tools were requested but couldn't be forwarded natively.
+			// Collect the full response and parse XML-format function calls from text.
+			let content = '';
+			for await (const part of response.stream) {
+				if (cts.token.isCancellationRequested) break;
+				if (part instanceof vscode.LanguageModelTextPart) {
+					content += part.value;
+				}
 			}
-		}
 
-		// Final chunk
-		if (!cts.token.isCancellationRequested) {
-			const final = {
-				id: requestId,
-				object: 'chat.completion.chunk',
-				created,
-				model: modelId,
-				choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
-			};
-			res.write(`data: ${JSON.stringify(final)}\n\n`);
-			res.write('data: [DONE]\n\n');
+			if (!cts.token.isCancellationRequested) {
+				const parsed = content.includes('<function_calls>')
+					? parseXmlToolCalls(content)
+					: { cleanedText: content, toolCalls: [] as any[] };
+
+				if (parsed.cleanedText) {
+					const chunk = {
+						id: requestId,
+						object: 'chat.completion.chunk',
+						created,
+						model: modelId,
+						choices: [{
+							index: 0,
+							delta: { role: 'assistant' as const, content: parsed.cleanedText },
+							finish_reason: null,
+						}],
+					};
+					res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+				}
+
+				for (let i = 0; i < parsed.toolCalls.length; i++) {
+					const tc = parsed.toolCalls[i];
+					const chunk = {
+						id: requestId,
+						object: 'chat.completion.chunk',
+						created,
+						model: modelId,
+						choices: [{
+							index: 0,
+							delta: {
+								tool_calls: [{
+									index: i,
+									id: tc.id,
+									type: 'function',
+									function: tc.function,
+								}],
+							},
+							finish_reason: null,
+						}],
+					};
+					res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+				}
+
+				const final = {
+					id: requestId,
+					object: 'chat.completion.chunk',
+					created,
+					model: modelId,
+					choices: [{
+						index: 0,
+						delta: {},
+						finish_reason: parsed.toolCalls.length > 0 ? 'tool_calls' : 'stop',
+					}],
+				};
+				res.write(`data: ${JSON.stringify(final)}\n\n`);
+				res.write('data: [DONE]\n\n');
+			}
+		} else {
+			// Normal streaming mode with native tool calling support
+			let hasToolCalls = false;
+			let toolCallIndex = 0;
+			let isFirstDelta = true;
+
+			for await (const part of response.stream) {
+				if (cts.token.isCancellationRequested) break;
+
+				if (part instanceof vscode.LanguageModelTextPart) {
+					const chunk = {
+						id: requestId,
+						object: 'chat.completion.chunk',
+						created,
+						model: modelId,
+						choices: [{
+							index: 0,
+							delta: {
+								...(isFirstDelta && { role: 'assistant' as const }),
+								content: part.value,
+							},
+							finish_reason: null,
+						}],
+					};
+					isFirstDelta = false;
+					res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+				} else if (part instanceof vscode.LanguageModelToolCallPart) {
+					hasToolCalls = true;
+					const chunk = {
+						id: requestId,
+						object: 'chat.completion.chunk',
+						created,
+						model: modelId,
+						choices: [{
+							index: 0,
+							delta: {
+								...(isFirstDelta && { role: 'assistant' as const }),
+								tool_calls: [{
+									index: toolCallIndex++,
+									id: part.callId || `call_${randomUUID()}`,
+									type: 'function',
+									function: { name: part.name, arguments: JSON.stringify(part.input) },
+								}],
+							},
+							finish_reason: null,
+						}],
+					};
+					isFirstDelta = false;
+					res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+				}
+			}
+
+			// Final chunk
+			if (!cts.token.isCancellationRequested) {
+				const final = {
+					id: requestId,
+					object: 'chat.completion.chunk',
+					created,
+					model: modelId,
+					choices: [{
+						index: 0,
+						delta: {},
+						finish_reason: hasToolCalls ? 'tool_calls' : 'stop',
+					}],
+				};
+				res.write(`data: ${JSON.stringify(final)}\n\n`);
+				res.write('data: [DONE]\n\n');
+			}
 		}
 	} catch (err: any) {
 		if (!cts.token.isCancellationRequested) {


### PR DESCRIPTION
## Summary

Fixes #6 — **Plaintext response for function calling**

When tools are passed to OpenWire but the VS Code LM API can't forward them natively, Claude falls back to outputting XML function_calls as plaintext. Additionally, Anthropic-style content arrays were being serialised as raw JSON instead of extracted as text.

## Changes

### Content normalisation
- Flattens Anthropic-style content part arrays into plain strings
- Handles mixed string/object arrays, null, and other edge cases
- Prevents raw JSON from leaking into model responses

### XML tool call fallback
- Detects Claude's XML function_calls output when native tool forwarding unavailable
- Converts to standard OpenAI-format tool_calls objects with proper IDs
- Applied in both non-streaming and streaming paths

### Streaming improvements
- Buffered fallback for when tools are requested but can't be forwarded natively
- finish_reason now correctly returns tool_calls instead of always stop
- First delta chunk includes role: assistant per OpenAI SSE spec
- Tool call index increments correctly for multiple tool calls

### Tests
- 12 unit tests covering normalizeContent and parseXmlToolCalls

### Docs
- Provider compatibility matrix added to README
- Feature list updated

### Version
- Bumped to 0.2.0
