### PR TITLE
fix: forward tools as plain objects instead of non-existent class constructors

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,5 +7,7 @@ src/**
 .gitignore
 esbuild.js
 tsconfig.json
+vitest.config.*
 **/*.map
 **/*.ts
+**/*.test.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
-	"name": "copilot-relay",
-	"version": "0.1.1",
+	"name": "open-wire",
+	"version": "0.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "copilot-relay",
-			"version": "0.1.1",
+			"name": "open-wire",
+			"version": "0.2.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^25.3.2",
 				"@types/vscode": "^1.95.0",
 				"@vscode/vsce": "^3.0.0",
 				"esbuild": "^0.27.3",
-				"typescript": "^5.7.0"
+				"typescript": "^5.7.0",
+				"vitest": "^4.0.0"
 			},
 			"engines": {
 				"vscode": "^1.95.0"
@@ -672,6 +673,13 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -709,6 +717,356 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+			"integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+			"integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+			"integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+			"integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-arm64": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+			"integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-x64": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+			"integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+			"integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+			"integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+			"integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+			"integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-gnu": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+			"integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-musl": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+			"integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+			"integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-musl": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+			"integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+			"integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-musl": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+			"integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+			"integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+			"integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+			"integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-openbsd-x64": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+			"integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+			"integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+			"integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+			"integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-gnu": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+			"integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+			"integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
 		},
 		"node_modules/@secretlint/config-creator": {
 			"version": "10.2.2",
@@ -921,6 +1279,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@textlint/ast-node-types": {
 			"version": "15.5.2",
 			"resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.5.2.tgz",
@@ -1027,6 +1392,31 @@
 				"@textlint/ast-node-types": "15.5.2"
 			}
 		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/node": {
 			"version": "25.3.2",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.2.tgz",
@@ -1071,6 +1461,117 @@
 			},
 			"engines": {
 				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@vitest/expect": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+			"integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.0.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.0.18",
+				"@vitest/utils": "4.0.18",
+				"chai": "^6.2.1",
+				"tinyrainbow": "^3.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+			"integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.0.18",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0-0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+			"integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+			"integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.0.18",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+			"integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.0.18",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+			"integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+			"integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.0.18",
+				"tinyrainbow": "^3.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vscode/vsce": {
@@ -1494,6 +1995,16 @@
 			"dev": true,
 			"license": "Python-2.0"
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/astral-regex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -1711,6 +2222,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/chalk": {
@@ -2195,6 +2716,13 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/es-module-lexer": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -2266,6 +2794,16 @@
 				"@esbuild/win32-x64": "0.27.3"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/expand-template": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -2275,6 +2813,16 @@
 			"optional": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -2429,6 +2977,21 @@
 			},
 			"engines": {
 				"node": ">=14.14"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/function-bind": {
@@ -3050,6 +3613,16 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
 		"node_modules/markdown-it": {
 			"version": "14.1.1",
 			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
@@ -3179,6 +3752,25 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/nanoid": {
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
 		"node_modules/napi-build-utils": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -3248,6 +3840,17 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/obug": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT"
 		},
 		"node_modules/once": {
 			"version": "1.4.0",
@@ -3382,6 +3985,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -3417,6 +4027,35 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.8",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.11",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
 			}
 		},
 		"node_modules/prebuild-install": {
@@ -3580,6 +4219,51 @@
 			"engines": {
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/rollup": {
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+			"integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "1.0.8"
+			},
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=18.0.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@rollup/rollup-android-arm-eabi": "4.59.0",
+				"@rollup/rollup-android-arm64": "4.59.0",
+				"@rollup/rollup-darwin-arm64": "4.59.0",
+				"@rollup/rollup-darwin-x64": "4.59.0",
+				"@rollup/rollup-freebsd-arm64": "4.59.0",
+				"@rollup/rollup-freebsd-x64": "4.59.0",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+				"@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+				"@rollup/rollup-linux-arm64-gnu": "4.59.0",
+				"@rollup/rollup-linux-arm64-musl": "4.59.0",
+				"@rollup/rollup-linux-loong64-gnu": "4.59.0",
+				"@rollup/rollup-linux-loong64-musl": "4.59.0",
+				"@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+				"@rollup/rollup-linux-ppc64-musl": "4.59.0",
+				"@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+				"@rollup/rollup-linux-riscv64-musl": "4.59.0",
+				"@rollup/rollup-linux-s390x-gnu": "4.59.0",
+				"@rollup/rollup-linux-x64-gnu": "4.59.0",
+				"@rollup/rollup-linux-x64-musl": "4.59.0",
+				"@rollup/rollup-openbsd-x64": "4.59.0",
+				"@rollup/rollup-openharmony-arm64": "4.59.0",
+				"@rollup/rollup-win32-arm64-msvc": "4.59.0",
+				"@rollup/rollup-win32-ia32-msvc": "4.59.0",
+				"@rollup/rollup-win32-x64-gnu": "4.59.0",
+				"@rollup/rollup-win32-x64-msvc": "4.59.0",
+				"fsevents": "~2.3.2"
 			}
 		},
 		"node_modules/run-applescript": {
@@ -3856,6 +4540,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/signal-exit": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -3949,6 +4640,16 @@
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
 			}
 		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/spdx-correct": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -3984,6 +4685,20 @@
 			"integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
 			"dev": true,
 			"license": "CC0-1.0"
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
@@ -4226,6 +4941,81 @@
 				"url": "https://bevry.me/fund"
 			}
 		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+			"integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+			"integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/tmp": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -4422,6 +5212,203 @@
 				"url": "https://bevry.me/fund"
 			}
 		},
+		"node_modules/vite": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "^0.27.0",
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.6",
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.15"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"lightningcss": "^1.21.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/vitest": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+			"integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.0.18",
+				"@vitest/mocker": "4.0.18",
+				"@vitest/pretty-format": "4.0.18",
+				"@vitest/runner": "4.0.18",
+				"@vitest/snapshot": "4.0.18",
+				"@vitest/spy": "4.0.18",
+				"@vitest/utils": "4.0.18",
+				"es-module-lexer": "^1.7.0",
+				"expect-type": "^1.2.2",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^3.10.0",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.0.3",
+				"vite": "^6.0.0 || ^7.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.0.18",
+				"@vitest/browser-preview": "4.0.18",
+				"@vitest/browser-webdriverio": "4.0.18",
+				"@vitest/ui": "4.0.18",
+				"happy-dom": "*",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/whatwg-encoding": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -4473,6 +5460,23 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "open-wire",
 	"displayName": "OpenWire",
 	"description": "Expose VS Code language models as an OpenAI-compatible REST API for agents and tools",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"publisher": "lewiswigmore",
 	"license": "MIT",
 	"icon": "media/icon.png",
@@ -140,13 +140,15 @@
 		"watch": "node esbuild.js --watch",
 		"vscode:prepublish": "node esbuild.js --production",
 		"package": "vsce package",
-		"lint": "tsc --noEmit"
+		"lint": "tsc --noEmit",
+		"test": "vitest run"
 	},
 	"devDependencies": {
 		"@types/node": "^25.3.2",
 		"@types/vscode": "^1.95.0",
 		"@vscode/vsce": "^3.0.0",
 		"esbuild": "^0.27.3",
-		"typescript": "^5.7.0"
+		"typescript": "^5.7.0",
+		"vitest": "^4.0.0"
 	}
 }

--- a/src/routes/chat.test.ts
+++ b/src/routes/chat.test.ts
@@ -1,11 +1,9 @@
-import * as assert from 'assert';
+import { describe, it, expect } from 'vitest';
 
 /**
  * Standalone copies of the pure functions from chat.ts for testing
  * (the originals depend on the vscode module which isn't available outside the extension host).
  */
-
-// -- normalizeContent ---------------------------------------------------------
 
 function normalizeContent(content: unknown): string {
 	if (typeof content === 'string') return content;
@@ -18,8 +16,6 @@ function normalizeContent(content: unknown): string {
 	if (content == null) return '';
 	return String(content);
 }
-
-// -- parseXmlToolCalls --------------------------------------------------------
 
 function parseXmlToolCalls(text: string): { cleanedText: string; toolCalls: { name: string; arguments: string }[] } {
 	const toolCalls: { name: string; arguments: string }[] = [];
@@ -42,107 +38,85 @@ function parseXmlToolCalls(text: string): { cleanedText: string; toolCalls: { na
 	return { cleanedText: cleaned.trim(), toolCalls };
 }
 
-// =============================================================================
-// Tests
-// =============================================================================
+describe('normalizeContent', () => {
+	it('passes through plain strings', () => {
+		expect(normalizeContent('hello')).toBe('hello');
+	});
 
-let passed = 0;
-let failed = 0;
+	it('extracts text from Anthropic content array', () => {
+		const input = [{ type: 'text', text: 'Hello ' }, { type: 'text', text: 'world' }];
+		expect(normalizeContent(input)).toBe('Hello world');
+	});
 
-function test(name: string, fn: () => void) {
-	try {
-		fn();
-		passed++;
-		console.log(`  ✓ ${name}`);
-	} catch (e: any) {
-		failed++;
-		console.log(`  ✗ ${name}`);
-		console.log(`    ${e.message}`);
-	}
-}
+	it('handles mixed string and object arrays', () => {
+		const input = ['Hello ', { type: 'text', text: 'world' }];
+		expect(normalizeContent(input)).toBe('Hello world');
+	});
 
-console.log('\nnormalizeContent');
+	it('skips non-text content parts (e.g. images)', () => {
+		const input = [
+			{ type: 'text', text: 'desc: ' },
+			{ type: 'image_url', image_url: { url: 'data:...' } },
+		];
+		expect(normalizeContent(input)).toBe('desc: ');
+	});
 
-test('passes through plain strings', () => {
-	assert.strictEqual(normalizeContent('hello'), 'hello');
+	it('returns empty string for null/undefined', () => {
+		expect(normalizeContent(null)).toBe('');
+		expect(normalizeContent(undefined)).toBe('');
+	});
+
+	it('stringifies other types', () => {
+		expect(normalizeContent(42)).toBe('42');
+	});
 });
 
-test('extracts text from Anthropic content array', () => {
-	const input = [{ type: 'text', text: 'Hello ' }, { type: 'text', text: 'world' }];
-	assert.strictEqual(normalizeContent(input), 'Hello world');
+describe('parseXmlToolCalls', () => {
+	it('parses single function call', () => {
+		const input = `Let me check that.\n<function_calls>\n<invoke name="exec">\n<parameter name="command">gh auth status 2>&1</parameter>\n</invoke>\n</function_calls>`;
+		const { cleanedText, toolCalls } = parseXmlToolCalls(input);
+		expect(cleanedText).toBe('Let me check that.');
+		expect(toolCalls).toHaveLength(1);
+		expect(toolCalls[0].name).toBe('exec');
+		expect(JSON.parse(toolCalls[0].arguments)).toEqual({ command: 'gh auth status 2>&1' });
+	});
+
+	it('parses multiple function calls', () => {
+		const input = `<function_calls>\n<invoke name="read">\n<parameter name="path">/tmp/a.txt</parameter>\n</invoke>\n<invoke name="exec">\n<parameter name="command">ls -la</parameter>\n</invoke>\n</function_calls>`;
+		const { toolCalls } = parseXmlToolCalls(input);
+		expect(toolCalls).toHaveLength(2);
+		expect(toolCalls[0].name).toBe('read');
+		expect(toolCalls[1].name).toBe('exec');
+	});
+
+	it('parses multiple parameters', () => {
+		const input = `<function_calls>\n<invoke name="write">\n<parameter name="path">/tmp/out.txt</parameter>\n<parameter name="content">hello world</parameter>\n</invoke>\n</function_calls>`;
+		const { toolCalls } = parseXmlToolCalls(input);
+		expect(toolCalls).toHaveLength(1);
+		const args = JSON.parse(toolCalls[0].arguments);
+		expect(args.path).toBe('/tmp/out.txt');
+		expect(args.content).toBe('hello world');
+	});
+
+	it('returns original text when no function calls present', () => {
+		const input = 'Just a normal response.';
+		const { cleanedText, toolCalls } = parseXmlToolCalls(input);
+		expect(cleanedText).toBe('Just a normal response.');
+		expect(toolCalls).toHaveLength(0);
+	});
+
+	it('handles text before and after function calls', () => {
+		const input = `Before text.\n<function_calls>\n<invoke name="exec">\n<parameter name="command">echo hi</parameter>\n</invoke>\n</function_calls>\nAfter text.`;
+		const { cleanedText, toolCalls } = parseXmlToolCalls(input);
+		expect(cleanedText).toContain('Before text.');
+		expect(cleanedText).toContain('After text.');
+		expect(cleanedText).not.toContain('function_calls');
+		expect(toolCalls).toHaveLength(1);
+	});
+
+	it('handles multiple separate function_calls blocks', () => {
+		const input = `First call:\n<function_calls>\n<invoke name="exec">\n<parameter name="command">echo 1</parameter>\n</invoke>\n</function_calls>\nThen:\n<function_calls>\n<invoke name="exec">\n<parameter name="command">echo 2</parameter>\n</invoke>\n</function_calls>`;
+		const { toolCalls } = parseXmlToolCalls(input);
+		expect(toolCalls).toHaveLength(2);
+	});
 });
-
-test('handles mixed string and object arrays', () => {
-	const input = ['Hello ', { type: 'text', text: 'world' }];
-	assert.strictEqual(normalizeContent(input), 'Hello world');
-});
-
-test('skips non-text content parts (e.g. images)', () => {
-	const input = [
-		{ type: 'text', text: 'desc: ' },
-		{ type: 'image_url', image_url: { url: 'data:...' } },
-	];
-	assert.strictEqual(normalizeContent(input), 'desc: ');
-});
-
-test('returns empty string for null/undefined', () => {
-	assert.strictEqual(normalizeContent(null), '');
-	assert.strictEqual(normalizeContent(undefined), '');
-});
-
-test('stringifies other types', () => {
-	assert.strictEqual(normalizeContent(42), '42');
-});
-
-console.log('\nparseXmlToolCalls');
-
-test('parses single function call', () => {
-	const input = `Let me check that.\n<function_calls>\n<invoke name="exec">\n<parameter name="command">gh auth status 2>&1</parameter>\n</invoke>\n</function_calls>`;
-	const { cleanedText, toolCalls } = parseXmlToolCalls(input);
-	assert.strictEqual(cleanedText, 'Let me check that.');
-	assert.strictEqual(toolCalls.length, 1);
-	assert.strictEqual(toolCalls[0].name, 'exec');
-	assert.deepStrictEqual(JSON.parse(toolCalls[0].arguments), { command: 'gh auth status 2>&1' });
-});
-
-test('parses multiple function calls', () => {
-	const input = `<function_calls>\n<invoke name="read">\n<parameter name="path">/tmp/a.txt</parameter>\n</invoke>\n<invoke name="exec">\n<parameter name="command">ls -la</parameter>\n</invoke>\n</function_calls>`;
-	const { toolCalls } = parseXmlToolCalls(input);
-	assert.strictEqual(toolCalls.length, 2);
-	assert.strictEqual(toolCalls[0].name, 'read');
-	assert.strictEqual(toolCalls[1].name, 'exec');
-});
-
-test('parses multiple parameters', () => {
-	const input = `<function_calls>\n<invoke name="write">\n<parameter name="path">/tmp/out.txt</parameter>\n<parameter name="content">hello world</parameter>\n</invoke>\n</function_calls>`;
-	const { toolCalls } = parseXmlToolCalls(input);
-	assert.strictEqual(toolCalls.length, 1);
-	const args = JSON.parse(toolCalls[0].arguments);
-	assert.strictEqual(args.path, '/tmp/out.txt');
-	assert.strictEqual(args.content, 'hello world');
-});
-
-test('returns original text when no function calls present', () => {
-	const input = 'Just a normal response.';
-	const { cleanedText, toolCalls } = parseXmlToolCalls(input);
-	assert.strictEqual(cleanedText, 'Just a normal response.');
-	assert.strictEqual(toolCalls.length, 0);
-});
-
-test('handles text before and after function calls', () => {
-	const input = `Before text.\n<function_calls>\n<invoke name="exec">\n<parameter name="command">echo hi</parameter>\n</invoke>\n</function_calls>\nAfter text.`;
-	const { cleanedText, toolCalls } = parseXmlToolCalls(input);
-	assert.ok(cleanedText.includes('Before text.'));
-	assert.ok(cleanedText.includes('After text.'));
-	assert.ok(!cleanedText.includes('function_calls'));
-	assert.strictEqual(toolCalls.length, 1);
-});
-
-test('handles multiple separate function_calls blocks', () => {
-	const input = `First call:\n<function_calls>\n<invoke name="exec">\n<parameter name="command">echo 1</parameter>\n</invoke>\n</function_calls>\nThen:\n<function_calls>\n<invoke name="exec">\n<parameter name="command">echo 2</parameter>\n</invoke>\n</function_calls>`;
-	const { toolCalls } = parseXmlToolCalls(input);
-	assert.strictEqual(toolCalls.length, 2);
-});
-
-console.log(`\n${passed} passed, ${failed} failed\n`);
-process.exit(failed > 0 ? 1 : 0);

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -118,17 +118,15 @@ export async function processChatCompletion(
 	const lmMessages = toVscodeMessages(messages);
 	const options: vscode.LanguageModelChatRequestOptions = {};
 
-	// Forward tools if provided (guard: LanguageModelToolInputSchema may not exist in older VS Code)
-	if (payload?.tools && Array.isArray(payload.tools) && payload.tools.length > 0
-		&& typeof vscode.LanguageModelToolInformation === 'function'
-		&& typeof vscode.LanguageModelToolInputSchema?.from === 'function') {
+	// Forward tools as plain LanguageModelChatTool objects
+	if (payload?.tools && Array.isArray(payload.tools) && payload.tools.length > 0) {
 		options.tools = payload.tools.map((t: any) => {
 			const fn = t.function || t;
-			return new vscode.LanguageModelToolInformation(
-				fn.name,
-				fn.description || '',
-				fn.parameters ? vscode.LanguageModelToolInputSchema.from(fn.parameters) : vscode.LanguageModelToolInputSchema.from({}),
-			);
+			return {
+				name: fn.name,
+				description: fn.description || '',
+				inputSchema: fn.parameters || {},
+			};
 		});
 		const tc = payload.tool_choice;
 		options.toolMode = (tc === 'required' || tc === 'any')
@@ -219,16 +217,14 @@ export async function processStreamingChatCompletion(
 	const lmMessages = toVscodeMessages(messages);
 	const options: vscode.LanguageModelChatRequestOptions = {};
 
-	if (payload?.tools && Array.isArray(payload.tools) && payload.tools.length > 0
-		&& typeof vscode.LanguageModelToolInformation === 'function'
-		&& typeof vscode.LanguageModelToolInputSchema?.from === 'function') {
+	if (payload?.tools && Array.isArray(payload.tools) && payload.tools.length > 0) {
 		options.tools = payload.tools.map((t: any) => {
 			const fn = t.function || t;
-			return new vscode.LanguageModelToolInformation(
-				fn.name,
-				fn.description || '',
-				fn.parameters ? vscode.LanguageModelToolInputSchema.from(fn.parameters) : vscode.LanguageModelToolInputSchema.from({}),
-			);
+			return {
+				name: fn.name,
+				description: fn.description || '',
+				inputSchema: fn.parameters || {},
+			};
 		});
 		const tc = payload.tool_choice;
 		options.toolMode = (tc === 'required' || tc === 'any')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
 		"sourceMap": true
 	},
 	"include": ["src/**/*.ts"],
-	"exclude": ["node_modules", "dist", "out"]
+	"exclude": ["node_modules", "dist", "out", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Problem

LanguageModelToolInformation is a TypeScript interface, not a runtime class. The guard typeof vscode.LanguageModelToolInformation === 'function' was always false, silently dropping all tools from API requests. The model never knew tools existed.

## Fix

Replace class constructor instantiation with plain objects matching the LanguageModelChatTool interface. Applied to both streaming and non-streaming code paths.

## Also

- Convert tests to proper vitest describe/it format
- Add vitest as devDependency + test script
- Exclude test files from tsconfig.json and .vscodeignore
- Bump version to 0.2.1

## Testing

- 12/12 unit tests pass
- tsc --noEmit clean
- Verified via curl: tool calls return finish_reason: tool_calls
- End-to-end verified via OpenClaw Telegram: exec, read, web_search, web_fetch all working
